### PR TITLE
feat: be able to pass rabbit url as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ Check below for supported options and default values.
 - `durable` - Defaults to true.
 - `autoDelete` - Defaults to false.
 - `deadLetterExchange` - By default all queues are created with a dead letter exchange. The name defaults to the name of the exchange following the `.dead` suffix. If you want to disable the dead letter exchange , set it as `false`.
-- `logger` - Defaults to Bunyan logger, but can receive a custom logger
+- `logger` - Defaults to Bunyan logger, but can receive a custom logger.
+- `rabbitUrl` - (Optional) RabbitMQ connection URL string. Defaults to 'amqp://localhost'.
+- `rabbit` - (Optional) Jackrabbit connection instance, in case you want to build your own. Make sure to use this if you want the connection to be shared amongst several minions.
 
 ### Programmatic use
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,6 @@
 const jackrabbit = require('@pager/jackrabbit')
 const { EventEmitter } = require('events')
 const debug = require('debug')('minion')
-const rabbit = jackrabbit(process.env.RABBIT_URL || 'amqp://localhost')
 
 const pluck = (object, keys) => {
     return Object.keys(object).reduce((result, key) => {
@@ -16,7 +15,7 @@ const pluck = (object, keys) => {
 
 const queueOptions = ['name', 'key', 'keys', 'exclusive', 'durable', 'autoDelete', 'deadLetterExchange']
 
-const createPublisher = (options) => (message, key) => {
+const createPublisher = (rabbit, options) => (message, key) => {
 
     const exchange = rabbit[options.exchangeType](options.exchangeName)
 
@@ -24,7 +23,7 @@ const createPublisher = (options) => (message, key) => {
     exchange.publish(message, { key: key || options.key })
 }
 
-const createService = (handler, options) => {
+const createService = (rabbit, handler, options) => {
 
     const eventEmitter = new EventEmitter()
 
@@ -62,7 +61,7 @@ const createService = (handler, options) => {
         })
     }
 
-    const publish = createPublisher(options)
+    const publish = createPublisher(rabbit, options)
 
     return Object.assign(eventEmitter, {
         start,
@@ -100,8 +99,9 @@ module.exports = (handler = { name: 'minion' }, settingsOverride = {}) => {
     const options = Object.assign({}, defaults, settings)
     options.deadLetterExchange = options.deadLetterExchange || undefined
 
+    const rabbit = options.rabbit || jackrabbit(options.rabbitUrl || 'amqp://localhost')
     if (isService) {
-        const service = createService(handler, options)
+        const service = createService(rabbit, handler, options)
         if (options.autoStart) {
             service.start()
         }
@@ -120,5 +120,5 @@ module.exports = (handler = { name: 'minion' }, settingsOverride = {}) => {
         return service
     }
 
-    return createPublisher(options)
+    return createPublisher(rabbit, options)
 }


### PR DESCRIPTION
Before this, the rabbitMq connection was created inside of Minion, with no ability to overwrite it, with this changes we enable the ability to pass an exisiting jackrabbit instance in case we want to reuse it with other minions, and the ability if wanted to only provide a rabbit url connection string and let the minion start its own connection.
An important side effect of this changes is that we start a single connection for every Minion we create if we don't provide the connection. Before, as the jackrabbit instance was created globally, it became shared by default.
It means that we need to be more careful on how we create Minions.