### PR TITLE
feat: make jackrabbit connection public

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,6 +121,7 @@ module.exports = (handler = { name: 'minion' }, settingsOverride = {}) => {
             debug('handler Error:', error)
         })
 
+        service.connection = rabbit
         return service
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,11 +100,6 @@ module.exports = (handler = { name: 'minion' }, settingsOverride = {}) => {
     const options = Object.assign({}, defaults, settings)
     options.deadLetterExchange = options.deadLetterExchange || undefined
 
-    rabbit.on('error', (error) => {
-        debug('connection error', error)
-        throw error
-    })
-
     if (isService) {
         const service = createService(handler, options)
         if (options.autoStart) {


### PR DESCRIPTION
Publish connection object, so clients can listen to connection events and handle connection errors themselves