### PR TITLE
feat: pass original message data as second param

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,8 +47,8 @@ const createService = (rabbit, handler, options) => {
         const queue = exchange.queue(pluck(options, queueOptions))
         queue.on('connected', () => {
 
-            queue.consume((payload, ack, nack) => {
-                handle(payload).then((response) => {
+            queue.consume((payload, ack, nack, metadata) => {
+                handle(payload, metadata).then((response) => {
                     ack(response)
                     eventEmitter.emit('response', response)
                 }).catch((error) => {
@@ -64,9 +64,10 @@ const createService = (rabbit, handler, options) => {
     const publish = createPublisher(rabbit, options)
 
     return Object.assign(eventEmitter, {
-        start,
+        handle,
+        options,
         publish,
-        handle
+        start,
     })
 }
 


### PR DESCRIPTION
we currently don't have the original message data as part of the object being passed to handlers.

This is an example of the data included:
```javascript
{ 
     fields: {
        consumerTag: 'amq.ctag-GmXoPFSMRaxOs873Jlua8g',
        deliveryTag: 1,
        redelivered: false,
        exchange: 'pager',
        routingKey: 'events.something.happened'
     },
     properties: {
        contentType: 'application/json',
        contentEncoding: undefined,
        headers: {},
        deliveryMode: 1,
        priority: undefined,
        correlationId: undefined,
        replyTo: undefined,
        expiration: undefined,
        messageId: undefined,
        timestamp: undefined,
        type: undefined,
        userId: undefined,
        appId: undefined,
        clusterId: undefined
    }
}
```