### PR TITLE
feat: include and emit message metadata on event handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,9 +30,9 @@ const createService = (rabbit, handler, options) => {
 
     const eventEmitter = new EventEmitter()
 
-    const handle = (message) => {
+    const handle = (message, metadata) => {
 
-        eventEmitter.emit('message', message)
+        eventEmitter.emit('message', message, metadata)
 
         return new Promise((resolve, reject) => {
 
@@ -40,7 +40,7 @@ const createService = (rabbit, handler, options) => {
                 reject(new Error('Ack timeout'))
             }, options.timeout || 30000)
 
-            resolve(handler(message))
+            resolve(handler(message, metadata))
         })
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -45,6 +45,32 @@ test('acks simple handler', async t => {
     t.true(res)
 })
 
+test('acks simple handler with metadata', async t => {
+    const handler = (message, meta) => {
+      return meta
+    }
+
+    const service = minion(handler, internals.settings)
+    const message = { hola: 'mundo' }
+
+    const res = await service.handle(message, 'i am meta')
+    t.is(res, 'i am meta')
+})
+
+test('emmitter emits message', async t => {
+    const handler = () => true
+
+    const service = minion(handler, internals.settings)
+    
+    service.on('message', (message, meta) => {
+        t.is(message, 'i am message')
+        t.is(meta, 'i am meta')
+    })
+
+    await service.handle('i am message', 'i am meta')
+
+    t.plan(2)
+})
 
 test('acks async handler', async t => {
     const handler = async (message) => {


### PR DESCRIPTION
There's additional info when consuming message that we miss.

This makes sure that additional info gets included in the message handler and also emitted in the message event