### PR TITLE
feat: allow exchange injection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,9 +15,7 @@ const pluck = (object, keys) => {
 
 const queueOptions = ['name', 'key', 'keys', 'exclusive', 'durable', 'autoDelete', 'deadLetterExchange', 'prefetch']
 
-const createPublisher = (rabbit, options) => {
-
-    const exchange = rabbit[options.exchangeType](options.exchangeName)
+const createPublisher = (exchange, options) => {
 
     return (message, key) => {
 
@@ -26,7 +24,7 @@ const createPublisher = (rabbit, options) => {
     }
 }
 
-const createService = (rabbit, handler, options) => {
+const createService = (exchange, handler, options) => {
 
     const eventEmitter = new EventEmitter()
 
@@ -46,7 +44,6 @@ const createService = (rabbit, handler, options) => {
 
     const start = () => {
 
-        const exchange = rabbit[options.exchangeType](options.exchangeName)
         const queue = exchange.queue(pluck(options, queueOptions))
         queue.on('connected', () => {
 
@@ -64,7 +61,7 @@ const createService = (rabbit, handler, options) => {
         })
     }
 
-    const publish = createPublisher(rabbit, options)
+    const publish = createPublisher(exchange, options)
 
     return Object.assign(eventEmitter, {
         handle,
@@ -72,6 +69,17 @@ const createService = (rabbit, handler, options) => {
         publish,
         start,
     })
+}
+
+const createRabbitExchange = (options) => {
+
+    const rabbit = options.rabbit || jackrabbit(options.rabbitUrl || 'amqp://127.0.0.1')
+
+    if (options.exchange) {
+        return { rabbit, exchange: options.exchange };
+    }
+
+    return { rabbit, exchange: rabbit[options.exchangeType](options.exchangeName) };
 }
 
 module.exports = (handler = { name: 'minion' }, settingsOverride = {}) => {
@@ -103,9 +111,10 @@ module.exports = (handler = { name: 'minion' }, settingsOverride = {}) => {
     const options = Object.assign({}, defaults, settings)
     options.deadLetterExchange = options.deadLetterExchange || undefined
 
-    const rabbit = options.rabbit || jackrabbit(options.rabbitUrl || 'amqp://localhost')
+    const { exchange, rabbit } = createRabbitExchange(options);
+
     if (isService) {
-        const service = createService(rabbit, handler, options)
+        const service = createService(exchange, handler, options)
         if (options.autoStart) {
             service.start()
         }
@@ -124,5 +133,5 @@ module.exports = (handler = { name: 'minion' }, settingsOverride = {}) => {
         return service
     }
 
-    return createPublisher(rabbit, options)
+    return createPublisher(exchange, options)
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "minion": "./bin/minion.js"
   },
   "scripts": {
-    "test": "nyc ava --timeout=2m"
+    "test": "nyc ava --timeout=10s"
   },
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/pagerinc/minion#readme",
   "dependencies": {
-    "@pager/jackrabbit": "4.x",
+    "@pager/jackrabbit": "5.x",
     "debug": "4.x",
     "mri": "1.x"
   },


### PR DESCRIPTION
exchange creation per minion can abuse channels + connections with the rabbit server, especially in use with servers running many queues. to prevent a breaking change, we look for an exchange injection to use, and otherwise keep the same behavior