### PR TITLE
Consume on queue bound

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ const createService = (exchange, handler, options) => {
     const start = () => {
 
         const queue = exchange.queue(pluck(options, queueOptions))
-        queue.on('connected', () => {
+        queue.on('bound', () => {
 
             queue.consume((payload, ack, nack, metadata) => {
                 handle(payload, metadata).then((response) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pager/minion",
-  "version": "3.4.5",
+  "version": "3.5.0",
   "description": "Microservice Framework for RabbitMQ Workers",
   "main": "./lib/index.js",
   "files": [


### PR DESCRIPTION
The `connected` event doesn't guarantee that the queue bindings are created. This makes that some messages get consumed but not processed because the exchange doesn't know yet to which queue route them. Using the 'bound' event starts consuming when all the bindings are created, preventing the loss of messages.