### PR TITLE
fix: handler errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: dependencies-{{ checksum "package.json" }}
 
       - run: npm install
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: dependencies-{{ checksum "package.json" }}
+          key: v1-dependencies-{{ checksum "package.json" }}
 
       - run: npm install
       - run:

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,32 +43,38 @@ const createService = (exchange, handler, options) => {
         ]);
     }
 
+    const handleMessage = (payload, ack, nack, metadata) => {
+        handle(payload, metadata).then((response) => {
+            ack(response)
+            eventEmitter.emit('response', response)
+        }).catch((error) => {
+            nack({ requeue: options.requeue })
+            eventEmitter.emit('error', error)
+        })
+    }
+
     const start = () => {
 
         const queue = exchange.queue(pluck(options, queueOptions))
         queue.on('bound', () => {
-
-            queue.consume((payload, ack, nack, metadata) => {
-                handle(payload, metadata).then((response) => {
-                    ack(response)
-                    eventEmitter.emit('response', response)
-                }).catch((error) => {
-                    nack({ requeue: options.requeue })
-                    eventEmitter.emit('error', error)
-                })
-            })
-
+            queue.consume(handleMessage);
             eventEmitter.emit('ready', queue)
         })
     }
 
     const publish = createPublisher(exchange, options)
 
+    const stop = () => {
+        const queue = exchange.queue(pluck(options, queueOptions))
+        queue.off('bound', handleMessage);
+    }
+
     return Object.assign(eventEmitter, {
         handle,
         options,
         publish,
         start,
+        stop
     })
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,14 +32,15 @@ const createService = (exchange, handler, options) => {
 
         eventEmitter.emit('message', message, metadata)
 
-        return new Promise((resolve, reject) => {
+        return Promise.race([
+            handler(message, metadata),
+            new Promise((resolve, reject) => {
 
-            setTimeout(() => {
-                reject(new Error('Ack timeout'))
-            }, options.timeout || 30000)
-
-            resolve(handler(message, metadata))
-        })
+                setTimeout(() => {
+                    reject(new Error('Ack timeout'))
+                }, options.timeout || 30000)
+            })
+        ]);
     }
 
     const start = () => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,15 +32,20 @@ const createService = (exchange, handler, options) => {
 
         eventEmitter.emit('message', message, metadata)
 
-        return Promise.race([
-            handler(message, metadata),
-            new Promise((resolve, reject) => {
+        try {
+            return Promise.race([
+                handler(message, metadata),
+                new Promise((resolve, reject) => {
 
-                setTimeout(() => {
-                    reject(new Error('Ack timeout'))
-                }, options.timeout || 30000)
-            })
-        ]);
+                    setTimeout(() => {
+                        reject(new Error('Ack timeout'))
+                    }, options.timeout || 30000)
+                })
+            ]);
+        }
+        catch (e) {
+            return Promise.reject(e);
+        }
     }
 
     const handleMessage = (payload, ack, nack, metadata) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,38 +48,31 @@ const createService = (exchange, handler, options) => {
         }
     }
 
-    const handleMessage = (payload, ack, nack, metadata) => {
-        handle(payload, metadata).then((response) => {
-            ack(response)
-            eventEmitter.emit('response', response)
-        }).catch((error) => {
-            nack({ requeue: options.requeue })
-            eventEmitter.emit('error', error)
-        })
-    }
-
     const start = () => {
 
         const queue = exchange.queue(pluck(options, queueOptions))
         queue.on('bound', () => {
-            queue.consume(handleMessage);
+            queue.consume((payload, ack, nack, metadata) => {
+                handle(payload, metadata).then((response) => {
+                    ack(response)
+                    eventEmitter.emit('response', response)
+                }).catch((error) => {
+                    nack({ requeue: options.requeue })
+                    eventEmitter.emit('error', error)
+                })
+            });
+
             eventEmitter.emit('ready', queue)
         })
     }
 
     const publish = createPublisher(exchange, options)
 
-    const stop = () => {
-        const queue = exchange.queue(pluck(options, queueOptions))
-        queue.off('bound', handleMessage);
-    }
-
     return Object.assign(eventEmitter, {
         handle,
         options,
         publish,
         start,
-        stop
     })
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -233,7 +233,7 @@ test.cb('handles rejections', t => {
 test.cb('handles exceptions', t => {
 
     const myMessage = 'event';
-    const myHandler = async (message) => {
+    const myHandler = (message) => {
         throw new Error(`Error processing ${message}`)
     };
     const service = minion(myHandler, internals.settings)

--- a/test/index.js
+++ b/test/index.js
@@ -168,7 +168,6 @@ test.cb('publisher only', t => {
 
     service.on('response', (response) => {
         t.is(response, myMessage)
-        t.pass()
         t.end()
     });
 
@@ -196,7 +195,6 @@ test.cb('publisher with default Key', t => {
 
     service.on('response', (response) => {
         t.is(response, myMessage)
-        t.pass()
         t.end()
     });
 
@@ -214,7 +212,6 @@ test.cb('handles rejections', t => {
     service.on('error', (error) => {
 
         t.is(error, 'Error processing event')
-        t.pass()
         t.end()
     });
 
@@ -246,7 +243,6 @@ test.cb('handles exceptions', t => {
 
     service.on('error', (error) => {
         t.is(error.message, 'Error processing event')
-        t.pass()
         t.end()
     });
 
@@ -275,7 +271,6 @@ test.cb('it times out', t => {
 
     service.on('error', (error) => {
         t.is(error.message, 'Ack timeout')
-        t.pass()
         t.end()
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -220,7 +220,7 @@ test.serial('handles rejections', async t => {
 test.serial('handles exceptions', async t => {
 
     const myMessage = 'event';
-    const myHandler = async (message) => {
+    const myHandler = (message) => {
         throw new Error(`Error processing ${message}`)
     };
     const service = minion(myHandler, internals.settings);
@@ -244,7 +244,6 @@ test.serial('handles exceptions', async t => {
 test.serial('it times out', async t => {
 
     const myMessage = 'test message'
-
     const myHandler = (message) => {
         return new Promise((resolve) => {
             setTimeout(() => resolve(message), 10);


### PR DESCRIPTION
`resolve(handler(message, metadata))` expects the handler to always succeed, which causes unhandled rejections when it doesn't.