### PR TITLE
fix: remove timeout exception

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ const pluck = (object, keys) => {
     }, {});
 };
 
-const queueOptions = ['name', 'key', 'keys', 'exclusive', 'durable', 'autoDelete', 'deadLetterExchange', 'prefetch'];
+const queueOptions = ['name', 'key', 'keys', 'exclusive', 'durable', 'autoDelete', 'deadLetterExchange', 'prefetch', 'queueMode'];
 
 const createPublisher = (exchange, options) => {
 
@@ -36,21 +36,15 @@ const createService = (exchange, handler, options) => {
 
         eventEmitter.emit('message', message, metadata);
 
-        try {
-            return Promise.race([
-                handler(message, metadata),
-                new Promise((resolve, reject) => {
+        return new Promise((resolve, reject) => {
 
-                    setTimeout(() => {
-
-                        reject(new Error('Ack timeout'));
-                    }, options.timeout || 30000);
-                })
-            ]);
-        }
-        catch (e) {
-            return Promise.reject(e);
-        }
+            try {
+                resolve(handler(message, metadata));
+            }
+            catch (e) {
+                reject(e);
+            }
+        });
     };
 
     const start = () => {

--- a/test/index.js
+++ b/test/index.js
@@ -280,28 +280,4 @@ describe('Minion', () => {
         const error = await errorPromise;
         expect(error).to.be.error(`Error processing ${myMessage}`);
     });
-
-    it('it times out', async ({ context }) => {
-
-        const myMessage = 'test message';
-        const timeoutHandler = (message) => {
-
-            return new Promise((resolve) => {
-
-                setTimeout(() => resolve(message), 10);
-            });
-        };
-
-        const service = Minion(timeoutHandler, { ...context, timeout: 5 });
-        const ready = new Promise((resolve) => service.once('ready', resolve));
-        const errorPromise = new Promise((resolve) => service.once('error', resolve));
-
-        await ready;
-
-        const publish = Minion({ name: 'timeoutHandler' }, context);
-        publish(myMessage);
-
-        const error = await errorPromise;
-        expect(error).to.be.error('Ack timeout');
-    });
 });


### PR DESCRIPTION
This timeout mechanism is useless because when the timeout wins the promise race, the other handler promise is not canceled (as promises can't be canceled) and continues running. So the consumer will do a `nack` on the message but will continue processing it.