### PR TITLE
fix(rabbit): kill service on rabbit disconnection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,19 @@ const createService = (exchange, handler, options) => {
 
 const createRabbitExchange = (options) => {
 
-    const rabbit = options.rabbit || Jackrabbit(options.rabbitUrl || 'amqp://127.0.0.1');
+    let rabbit;
+    
+    if (options.rabbit) {
+        rabbit = options.rabbit;
+    } else {
+        rabbit = Jackrabbit(options.rabbitUrl || 'amqp://127.0.0.1');
+
+        rabbit.on('error', (err) => {
+
+            console.error({ err }, 'Rabbit connection error!');
+            process.exit(1);
+        });
+    }
 
     if (options.exchange) {
         return { rabbit, exchange: options.exchange };


### PR DESCRIPTION
- add listener for rabbit connection to check on error, to kill the process
- this will trigger a crashloop error in the k8s pod, which will make it to restart until rabbitmq is up and running