### PR TITLE
chore(FIN-3402): Migrate any references of gcr.io/.*/cloudbuilders to artifact registry

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,7 +28,7 @@ steps:
     waitFor: ['npm-ci', 'docker-compose']
 
   - id: npm-publish
-    name: 'gcr.io/$PROJECT_ID/cloudbuilders/npm:6.13.4'
+    name: 'us-east1-docker.pkg.dev/$PROJECT_ID/cloudbuilders/npm:6.13.4'
     secretEnv: ['NPM_TOKEN']
     env:
       - 'TAG_NAME=$TAG_NAME'


### PR DESCRIPTION
migrating any references of gcr.io/.*/cloudbuilders to artifact registry

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖